### PR TITLE
statutes: Change from Foundation to Association

### DIFF
--- a/statutes_en.txt
+++ b/statutes_en.txt
@@ -13,7 +13,7 @@ ARTICLE 1 : Constitution and naming
 
 An association is founded between the members, agreeing to the present statutes,
 and in accordance to the law of July the first, 1901 and the application decree
-of August, the sixteenth, 1901, and named Buildroot Foundation.
+of August, the sixteenth, 1901, and named Buildroot Association.
 
 ARTICLE 2 : Goal
 ----------------
@@ -21,7 +21,7 @@ ARTICLE 2 : Goal
 Buildroot is a project for the development of a free software, which goal is to
 simplify and automate the process of building embdeded systems.
 
-The goal for the Buildroot Foundation association (thereafter "the Association")
+The goal for the Buildroot Association (thereafter "the Association")
 is to support the Buildroot project.
 
 The Association has for goal to engage actions to promote, help develop and
@@ -171,7 +171,7 @@ of the tasks within the Association.
 
 
 Present statutes have been approved by the Constitutive Assembly of
-02/02/2016.
+17/03/2016.
 
 Names and signatures of the members of the Board:
 

--- a/statuts_fr.txt
+++ b/statuts_fr.txt
@@ -6,7 +6,7 @@ ARTICLE 1 : Constitution et dénomination
 
 Il est fondé entre les membres aux présents statuts une association régie par
 la loi du 1er juillet 1901 et le décret du 16 août 1901, ayant pour titre
-Buildroot Foundation.
+Buildroot Association.
 
 ARTICLE 2 : Buts
 ----------------
@@ -14,7 +14,7 @@ ARTICLE 2 : Buts
 Buildroot est un projet de développement d'un logiciel libre, ayant pour but
 de simplifier et automatiser le processus de création d'un système embarqué.
 
-L'association Buildroot Foundation (ci-aprés, "l'Association") se place dans
+L'association Buildroot Association (ci-aprés, "l'Association") se place dans
 une perspective de soutien au projet Buildroot.
 
 L'Association a pour objet d'engager toute action susceptible d'assurer la
@@ -173,7 +173,7 @@ tâches dans l'Association.
 
 
 Les présents statuts ont été approuvés par l'Assemblée Constitutive du
-02/02/2016.
+17/03/2016.
 
 Noms et signatures des membres du Conseil d'Administration :
 


### PR DESCRIPTION
The name could not be 'Buildroot Foundation' as french Law requires a
whole differents sets of rules to declare a foundation, which we are not
going to do.
So, we must change the name to 'Buildroot Association'.

To gain time, the date of the consituent meeting has been changed with
the approval of everyone involved (through mail).